### PR TITLE
Fix path issue when invoking theme

### DIFF
--- a/src/resumy/resumy.py
+++ b/src/resumy/resumy.py
@@ -51,11 +51,19 @@ def create_resume(config: Yaml,
                   theme_path: str,
                   metadata: DocumentMetadata) -> None:
     # 1. Retrieve theme
+    # Use relative path if theme was invoked by name
+    if theme_path[0] != '/':
+        theme_name = os.path.basename(os.path.normpath(theme_path))
+        package_path = f'themes/{theme_name}'
+    # Use absolute path if theme was invoked by absolute path
+    else:
+        package_path = theme_path
+
     env = jinja2.Environment(
-        loader=jinja2.FileSystemLoader('/'),
+        loader=jinja2.PackageLoader('resumy', package_path=package_path),
     )
     try:
-        template = env.get_template(f'{theme_path}/theme.html')
+        template = env.select_template('theme.html')
     except jinja2.exceptions.TemplateNotFound as err:
         raise IOError(f"No such file or directory: '{err}'")
 

--- a/src/resumy/resumy.py
+++ b/src/resumy/resumy.py
@@ -63,7 +63,7 @@ def create_resume(config: Yaml,
         loader=jinja2.PackageLoader('resumy', package_path=package_path),
     )
     try:
-        template = env.select_template('theme.html')
+        template = env.get_template('theme.html')
     except jinja2.exceptions.TemplateNotFound as err:
         raise IOError(f"No such file or directory: '{err}'")
 


### PR DESCRIPTION
Due to the way how theme paths are handled, non-default themes aren't loaded properly. These changes should fix this behavior by handling relative and absolute paths separately and utilizing Jinja's PackageLoader.

Since `cmd_build()` already parses the `theme_path` (lines 229-232), there may be simpler / more elegant ways to solve this. Is there any approach you prefer?