### PR TITLE
Feature: Allow using multiple Jinja file extensions

### DIFF
--- a/src/resumy/resumy.py
+++ b/src/resumy/resumy.py
@@ -55,7 +55,10 @@ def create_resume(config: Yaml,
         loader=jinja2.FileSystemLoader('/'),
     )
     try:
-        template = env.get_template(f'{theme_path}/theme.html')
+        extensions = ['.html', '.jinja', '.html.jinja', '.j2']
+        template_paths = [f"theme{extension}" for extension in extensions]
+
+        template = env.select_template(template_paths)
     except jinja2.exceptions.TemplateNotFound as err:
         raise IOError(f"No such file or directory: '{err}'")
 


### PR DESCRIPTION
Jinja template files may have different file extensions:

> Adding a .jinja extension, like user.html.jinja may make it easier for some IDEs or editor plugins [...]
(Source: https://jinja.palletsprojects.com/en/3.1.x/templates/)

If merged, resumy would support `.jinja`, `.html.jinja` an `.j2` files in addition to `.html`.

